### PR TITLE
✨Prevent switching page when target blank on links

### DIFF
--- a/opal/inesita-router/router.rb
+++ b/opal/inesita-router/router.rb
@@ -20,7 +20,7 @@ module Inesita
         unless respond_to?(:__a)
           alias_method :__a, :a
           define_method(:a) do |params = {}, &block|
-            params = { onclick: ->(e) { router.go_to(e.target.pathname) } }.merge(params)
+            params = { onclick: ->(e) { router.go_to(e.target.pathname) unless params[:target] == "_blank" } }.merge(params)
             __a(params, &block)
           end
         end


### PR DESCRIPTION
Hi!

Today, when using a link with `target: "_blank"`, when clicking on it, a new tab is open, but the router also triggers the click as a new entry. This is definitely not the behavior we want, because a new link open in a new tab should be considered like this, not like an internal link. 🙂