### PR TITLE
Enable link functionality for nested elements

### DIFF
--- a/opal/inesita-router/router.rb
+++ b/opal/inesita-router/router.rb
@@ -20,7 +20,7 @@ module Inesita
         unless respond_to?(:__a)
           alias_method :__a, :a
           define_method(:a) do |params = {}, &block|
-            params = { onclick: ->(e) { router.go_to(e.target.pathname) unless params[:target] == "_blank" } }.merge(params)
+            params = { onclick: ->(e) { router.go_to(e.currentTarget.pathname) unless params[:target] == "_blank" } }.merge(params)
             __a(params, &block)
           end
         end


### PR DESCRIPTION
This change makes it possible to trigger router events from elements nested inside `<a>`s by looking up the `pathname` property of the element to which the onclick event was added, instead of the child element which was actually clicked.